### PR TITLE
Register apps explicitly

### DIFF
--- a/app1/routes.go
+++ b/app1/routes.go
@@ -1,12 +1,10 @@
 package app1
 
 import (
-	"github.com/siredwin/multiurlimports/supercontext"
+	"github.com/labstack/echo"
 )
 
-func init(){
-	//Initiate the supercontext
-	e := supercontext.E
+func New(e *echo.Echo) {
 	// Name the routes for app1
 	app1routes := e.Group("/app1")
 	app1routes.Match([]string{"GET", "POST"}, "/view1", view1)

--- a/app2/routes.go
+++ b/app2/routes.go
@@ -1,12 +1,10 @@
 package app2
 
 import (
-	"github.com/siredwin/multiurlimports/supercontext"
+	"github.com/labstack/echo"
 )
 
-func init(){
-	//Initiate the supercontext
-	e := supercontext.E
+func New(e *echo.Echo) {
 	// Name the routes for app2
 	app2routes := e.Group("/app2")
 	app2routes.Match([]string{"GET", "POST"}, "/view3", view3)

--- a/app3/routes.go
+++ b/app3/routes.go
@@ -1,12 +1,10 @@
 package app3
 
 import (
-	"github.com/siredwin/multiurlimports/supercontext"
+	"github.com/labstack/echo"
 )
 
-func init(){
-	//Initiate the supercontext
-	e := supercontext.E
+func New(e *echo.Echo) {
 	// Name the routes for app3
 	app3routes := e.Group("/app3")
 	app3routes.Match([]string{"GET", "POST"}, "/view5", view5)

--- a/main.go
+++ b/main.go
@@ -1,22 +1,27 @@
 package main
 
 import (
-	_ "github.com/siredwin/multiurlimports/app1" // app1 views from init
-	_ "github.com/siredwin/multiurlimports/app2" // app2 views from init
-	_ "github.com/siredwin/multiurlimports/app3" // app3 views from init
+	"github.com/labstack/echo"
 	"github.com/labstack/echo/middleware"
-	"github.com/siredwin/multiurlimports/supercontext"
+	"github.com/siredwin/multiurlimports/app1"
+	"github.com/siredwin/multiurlimports/app2"
+	"github.com/siredwin/multiurlimports/app3"
 )
 
-
 func main() {
-	e := supercontext.E // use our supercontext
+	e := echo.New()
 	e.Debug = true
 	// Middleware
 	e.Use(middleware.Logger())
 	e.Use(middleware.Recover())
 	e.Use(middleware.Secure())
 	e.Static("/static", "static")
+
+	// Register apps
+	app1.New(e)
+	app2.New(e)
+	app3.New(e)
+
 	// #*************** START SERVER *****************# //
 	e.Logger.Fatal(e.Start(":8000"))
 }

--- a/supercontext/supercontext.go
+++ b/supercontext/supercontext.go
@@ -1,7 +1,0 @@
-package supercontext
-
-import (
-	"github.com/labstack/echo"
-)
-
-var E = echo.New()


### PR DESCRIPTION
There are some undesired situations in the current implementation:
- importing package only for side effects
- use of init function
- exported package variable

All of the above tend to make apps less maintainable and flows harder to understand.

I propose to you an explicit way of building the main app using the other apps.